### PR TITLE
Pull out the most common boilerplate into its own mini-layout

### DIFF
--- a/content/venue.md
+++ b/content/venue.md
@@ -1,45 +1,32 @@
 +++
 title = "Venue"
+layout = "generic"
 +++
 
-<section class="row">
-    <div class="main-container">
-        <a id="top"></a>
-        <main class="container generic">
-            <div class="col-md-12 main">
-                <h1>Venue</h1>
-                <p>
-                    Riddel Hall, Queen's University Belfast
-                </p>
-                <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2312.571346010759!2d-5.937136684114829!3d54.576306080255215!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x486108e9a278df55%3A0x79f7e47de7983186!2sRiddel+Hall!5e0!3m2!1sen!2suk!4v1518300225307" frameborder="0" style="width:100%; height:450px; border:0" allowfullscreen></iframe>
+# Venue
 
-                <h3>Transport</h3>
-                <p>
-                    The nearest train station is Botanic, approximately 1 mile from the venue.
-                </p>
-                <p>
-                    Bus service 8a runs twice an hour from the city centre to the Stranmillis Mews stop outside Riddel Hall, also stopping on Bradbury Place near Botanic Station.
-                </p>
-                <p>
-                    Ample free parking is available on site. Bicycle stands are also provided.
-                </p>
+Riddel Hall, Queen's University Belfast
 
-                <p>Ride-sharing: we will attempt to put you in touch with others wishing to carpool or share a taxi from outside Belfast. Please fill in <a href='https://docs.google.com/forms/d/e/1FAIpQLSd8Al8tdNvCl_sXW7gFllotDpVTc9eWOcqeYacP4q38KSEGmg/viewform'>this form</a>.</p>
+<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2312.571346010759!2d-5.937136684114829!3d54.576306080255215!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x486108e9a278df55%3A0x79f7e47de7983186!2sRiddel+Hall!5e0!3m2!1sen!2suk!4v1518300225307" frameborder="0" style="width:100%; height:450px; border:0" allowfullscreen></iframe>
 
-                <h3>Accessibility</h3>
-                <p>
-                    Please see the <a href='/accessibility'>accessibility and access page</a> for more information.
-                </p>
+### Transport
 
-                <h3>After-Party</h3>
+The nearest train station is Botanic, approximately 1 mile from the venue.
 
-                <p>The After-Party will be held at the <a href="http://thebotanicinn.com/">Botanic Inn</a> from 18:30 onwards (food from 18:45). Complimentary food and drink tokens will be handed out after the closing plenary session in Riddel Hall. These cover a burger or chips (except where we have been made of additional dietary requirements) <em>and</em> a soft drink, Corona or red wine.</p>
+Bus service 8a runs twice an hour from the city centre to the Stranmillis Mews stop outside Riddel Hall, also stopping on Bradbury Place near Botanic Station.
 
-                <h3>Anything else</h3>
-                <p>
-                    If there is information that you feel should be here, but is not, please let us know at <a href="mailto:inbox@nidevconf.com">inbox@nidevconf.com</a>.
-                </p>
-            </div>
-        </main>
-    </div>
-</section>
+Ample free parking is available on site. Bicycle stands are also provided.
+
+Ride-sharing: we will attempt to put you in touch with others wishing to carpool or share a taxi from outside Belfast. Please fill in <a href='https://docs.google.com/forms/d/e/1FAIpQLSd8Al8tdNvCl_sXW7gFllotDpVTc9eWOcqeYacP4q38KSEGmg/viewform'>this form</a>.
+
+### Accessibility
+
+Please see the <a href='/accessibility'>accessibility and access page</a> for more information.
+
+### After-Party
+
+The After-Party will be held at the <a href="http://thebotanicinn.com/">Botanic Inn</a> from 18:30 onwards (food from 18:45). Complimentary food and drink tokens will be handed out after the closing plenary session in Riddel Hall. These cover a burger or chips (except where we have been made of additional dietary requirements) <em>and</em> a soft drink, Corona or red wine.
+
+### Anything else
+
+If there is information that you feel should be here, but is not, please let us know at <a href="mailto:inbox@nidevconf.com">inbox@nidevconf.com</a>.

--- a/themes/nidevconf/layouts/_default/generic.html
+++ b/themes/nidevconf/layouts/_default/generic.html
@@ -1,0 +1,16 @@
+{{ partial "header.html" . }}
+{{ partial "navbar.html" . }}
+<section class="row">
+    <div class="main-container">
+        <a id="top"></a>
+        <main class="container generic">
+            <div class="col-md-12 main">
+
+            {{ .Content }}
+
+            </div>
+        </main>
+    </div>
+</section>
+
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Ensure this works for generic, single-column pages, so that Markdown works fine in the content files, without needing to switch to wrapped HTML.