### PR TITLE
Update Homepage with Slogan, Testimonials and Conference Dates

### DIFF
--- a/themes/nidevconf/layouts/index.html
+++ b/themes/nidevconf/layouts/index.html
@@ -19,17 +19,13 @@
             <div class="row">
               <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 text-center">
                 <img alt="logo" class="logo" src="/img/NIDevConf2020.png">
-                <h1 class="text-white" style="margin-bottom: 0.5em;">NI DEVELOPER CONFERENCE 2020 POSTPONEMENT</h1>
-                <h2 class="text-white">
-                  New Date: Planned for the first week of October (5th - 11th) 2020
-                </p>
-                <p class="text-white">
-                  <strong>Please fill in the form below to help us create the best virtual experience for you!</strong>
-                </p>
-                <p class="text-white">
-                  In light of the significant concerns and the fluid situation surrounding the COVID-19 outbreak, the NIDC Committee has made the difficult decision to postpone this year’s conference and host it online. As NIDC is a volunteer run and community-led conference, the safety of everyone involved is paramount to us.  
-                  We would like to extend a massive thank you to all our supporters for your patience and we look forward to seeing you again (online) in October.
-                </p>
+                <span class="uppercase text-white">
+                  October 8th, 9th and 10th 2020, Online
+                  <br>
+                  <a class="highlight text-white" href="https://twitter.com/search?q=%23NIDC2020">#NIDC2020</a>
+                </span>
+                <h1 class="large-h1 text-white" style="margin-bottom: 0.5em;">Join the Northern Ireland developer family.</h1>
+                {{ partial "testimonials.html" . }}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description

Taking off the postponement notice and replacing it with the usual content. I also added the [#NIDC2020](https://twitter.com/search?q=%23NIDC2020) hashtag.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/89527116-b6ef3e80-d7e0-11ea-93a8-cde67d53d0f8.png) | ![image](https://user-images.githubusercontent.com/13058213/89527053-9e7f2400-d7e0-11ea-9b7e-88a2e01dd49b.png)