### PR TITLE
Update Title and Footer from 2019 to 2020

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-title = "Northern Ireland Developer Conference 2019"
+title = "Northern Ireland Developer Conference 2020"
 baseurl = "/"
 languageCode = "en-us"
 theme = "nidevconf"

--- a/themes/nidevconf/layouts/partials/footer.html
+++ b/themes/nidevconf/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     <div class="container">
       <div class="row">
         <div class="col-sm-7">
-          <span class="text-white">© Copyright 2019 Northern Ireland Developer Conference</span>
+          <span class="text-white">© Copyright 2020 Northern Ireland Developer Conference</span>
         </div>
 
         <div class="col-sm-5 text-right">


### PR DESCRIPTION
## Description

Oops, I was talking about NIDevConf with someone and got pointed to our Google search result looking like it's last years conference.

Ooops |
--- |
![image](https://user-images.githubusercontent.com/13058213/92108543-7d115800-eddf-11ea-9b3e-62b3cd6bbd7e.png)

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/92108506-6bc84b80-eddf-11ea-8d7a-883a741e4f74.png) | ![image](https://user-images.githubusercontent.com/13058213/92108513-6e2aa580-eddf-11ea-9c2e-0852eef8cc97.png)
![image](https://user-images.githubusercontent.com/13058213/92108457-5521f480-eddf-11ea-816e-1cd6cf8f6236.png) | ![image](https://user-images.githubusercontent.com/13058213/92108487-6408a700-eddf-11ea-858d-b79f72c6a426.png)
