### PR TITLE
Link to Sponsorhip Information from the Sponsors Page

### DIFF
--- a/themes/nidevconf/layouts/section/sponsors.html
+++ b/themes/nidevconf/layouts/section/sponsors.html
@@ -7,7 +7,9 @@
     <p>
       We encourage you to support our sponsors as they've all proved their commitment to the NI developer community by supporting us.
     </p>
-    
+    <p>
+      Would you like to become a sponsor? Get information on options and submit an enquiry through our <a href="/sponsorship">become a sponspor</a> page.
+    </p>
     {{ partial "sponsors.html" . }}
     <!-- {{ partial "sponsorshipflyer.html" . }} -->
   </div>


### PR DESCRIPTION
## Description

I didn't see a way to navigate to the `/sponsorship` page through the website. Now, we can do it through the sponsors page.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/92404251-fcc65c00-f12a-11ea-8d64-41b617b2ca55.png) | ![image](https://user-images.githubusercontent.com/13058213/92404260-ffc14c80-f12a-11ea-8a73-e3a149622256.png)