### PR TITLE
Update Ticket Platform for NIDC2020 to Hopin

### DIFF
--- a/themes/nidevconf/layouts/index.html
+++ b/themes/nidevconf/layouts/index.html
@@ -41,7 +41,7 @@
       
       <div class="container">
         <div class="row">
-          <a href="https://nidc2020.eventbrite.com/" class="block-content">
+          <a href="https://hopin.to/events/nidc2020" class="block-content">
             <div class="col-md-2 col-sm-4 text-center">
               <i>
                 <img class="icon" src="/img/icons/Starred Ticket-70.png" width="65" style="margin-top: -12px">

--- a/themes/nidevconf/layouts/partials/mainmenu.html
+++ b/themes/nidevconf/layouts/partials/mainmenu.html
@@ -29,7 +29,7 @@
           <a class="inner-link">NIDC2020</a>
           <ul class="nav-dropdown">
             <!-- <li><a class="inner-link" href="/agenda/">Agenda</a></li> -->
-            <li><a class="inner-link" href="https://nidc2020.eventbrite.com/">Tickets</a></li>
+            <li><a class="inner-link" href="https://hopin.to/events/nidc2020">Tickets</a></li>
             <li><a class="inner-link" href="/sessions/">Sessions</a></li>
             <li><a class="inner-link" href="/speakers/">Speakers</a></li>
             <li><a class="inner-link" href="/sponsors/">Sponsors</a></li>


### PR DESCRIPTION
## Description

Let's point people to get tickets on Hopin, rather than Eventbrite.